### PR TITLE
fix: update the resource path for raw-captures

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ app.post('/tree', async (req, res) => {
         };
         var options = {
           method: 'POST',
-          uri: config.fieldDataURL + "captures",
+          uri: config.fieldDataURL + "raw-captures",
           body: capture,
           json: true // Automatically stringifies the body to JSON
         };


### PR DESCRIPTION
The route for creating raw captures was updated to be `raw-captures` from `captures` and this needs to be reflected in the bulk-pack-transformer when creating the raw capture data.